### PR TITLE
use `install-includes` stanza for C headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Revision history for libBF-hs
 
+## 0.5.2 -- 2021-01-12
+
+* Use `install-includes` over `c-sources` for header files to avoid linker
+  issues.
+
+## 0.5.1 -- 2020-07-13
+
+* Add header files to `c-sources` field to include them in `sdist`.
+
 ## 0.5.0 -- 2020-07-01
 
 * First version. Released on an unsuspecting world.

--- a/libBF.cabal
+++ b/libBF.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.2
 
 name:                libBF
-version:             0.5.1
+version:             0.5.2
 synopsis:            A binding to the libBF library.
 description:         LibBF is a C library for working with arbitray precision
                      IEEE 754 floating point numbers.
@@ -38,12 +38,11 @@ library
   include-dirs:
     libbf-2020-01-19
 
-  includes:
+  install-includes:
+    libbf-2020-01-19/cutils.h
     libbf-2020-01-19/libbf.h
 
   c-sources:
-    libbf-2020-01-19/libbf.h
-    libbf-2020-01-19/cutils.h
     libbf-2020-01-19/cutils.c
     libbf-2020-01-19/libbf.c
     cbits/libbf-hs.c
@@ -64,4 +63,3 @@ test-suite libBF-tests
   main-is:            RunUnitTests.hs
   default-language:   Haskell2010
   build-depends:      base, libBF
-


### PR DESCRIPTION
Putting the header files in the `c-sources` field leads to linking problems with some linkers (I'm having issues with GNU gold (GNU Binutils 2.31.1) 1.16) as they see the same symbols twice.

@yav are you able to check whether this change puts the wanted files in the `sdist` directory, since that was the intent of the presence of these header files in the `c-sources` field?

If so, I think this change would be beneficial.