### PR TITLE
Don't leak the internal `LimbT` type in the public API

### DIFF
--- a/src/LibBF.hs
+++ b/src/LibBF.hs
@@ -363,7 +363,7 @@ bfFromBits opts bits
 
   opts' = opts <> allowSubnormal
 
-  p'         = p - 1                                       :: Int
+  p'         = fromIntegral p - 1                          :: Int
   eMask      = (1 `shiftL` e) - 1                          :: Int64
   pMask      = (1 `shiftL` p') - 1                         :: Integer
 
@@ -391,7 +391,7 @@ bfToBits opts bf = res
   e = getExpBits opts
   p = getPrecBits opts
 
-  p' = p - 1 :: Int
+  p' = fromIntegral p - 1 :: Int
 
   eMask = (1 `shiftL` e) - 1   :: Integer
   pMask = (1 `shiftL` p') - 1   :: Integer

--- a/src/LibBF/Opts.hsc
+++ b/src/LibBF/Opts.hsc
@@ -96,11 +96,11 @@ infPrec = BFOpts #{const BF_PREC_INF} 0
 
 -- | Use this many bits to represent the mantissa in the computation.
 -- The input should be in the interval defined by 'precMin' and 'precMax'
-precBits :: Int -> BFOpts
+precBits :: Word -> BFOpts
 precBits n = BFOpts (fromIntegral n) 0
 
 -- | Retrieve how many bits to represent the mantissa in the computation.
-getPrecBits :: BFOpts -> Int
+getPrecBits :: BFOpts -> Word
 getPrecBits (BFOpts n _) = fromIntegral n
 
 -- | Use the given rounding mode.
@@ -183,12 +183,12 @@ instance Semigroup ShowFmt where
   ShowFmt a x <> ShowFmt b y = ShowFmt (max a b) (x .|. y)
 
 {-| Show this many significant digits total . -}
-showFixed :: Word64 -> ShowFmt
-showFixed n = ShowFmt n #{const BF_FTOA_FORMAT_FIXED}
+showFixed :: Word -> ShowFmt
+showFixed n = ShowFmt (fromIntegral n) #{const BF_FTOA_FORMAT_FIXED}
 
 {-| Show this many digits after the decimal point. -}
-showFrac :: Word64 -> ShowFmt
-showFrac n = ShowFmt n #{const BF_FTOA_FORMAT_FRAC}
+showFrac :: Word -> ShowFmt
+showFrac n = ShowFmt (fromIntegral n) #{const BF_FTOA_FORMAT_FRAC}
 
 {-| Use as many digits as necessary to match the required precision
    rounding to nearest and the subnormal+exponent configuration of 'FlagsT'.
@@ -197,20 +197,20 @@ showFrac n = ShowFmt n #{const BF_FTOA_FORMAT_FRAC}
 
    Infinite precision, indicated by giving 'Nothing' for the precision
    is supported when the radix is a power of two. -}
-showFree :: Maybe Word64 -> ShowFmt
+showFree :: Maybe Word -> ShowFmt
 showFree mb = ShowFmt prec #{const BF_FTOA_FORMAT_FREE}
   where prec = case mb of
                  Nothing -> #{const BF_PREC_INF}
-                 Just n  -> n
+                 Just n  -> fromIntegral n
 
 
 {-| same as 'showFree' but uses the minimum number of digits
 (takes more computation time). -}
-showFreeMin :: Maybe Word64 -> ShowFmt
+showFreeMin :: Maybe Word -> ShowFmt
 showFreeMin mb = ShowFmt prec #{const BF_FTOA_FORMAT_FREE_MIN}
   where prec = case mb of
                  Nothing -> #{const BF_PREC_INF}
-                 Just n  -> n
+                 Just n  -> fromIntegral n
 
 
 


### PR DESCRIPTION
Uniformly use the architecture-dependent `Word` type to
represent bits of precision, and the `Int` type to represent
exponent bits.  Yes, it's odd to use a signed type for one
and an unsigned type for the other, but that's what the types
`libbf.h` are.

Hopefull this should allow the library to work properly on
32-bit systems.