### PR TITLE
Bring out libbf support for transcendentals

### DIFF
--- a/src/LibBF.hs
+++ b/src/LibBF.hs
@@ -44,6 +44,16 @@ module LibBF
   , bfFMA, bfMulWord, bfMulInt, bfMul2Exp
   , bfSqrt
   , bfPow
+  , bfConstPi
+  , bfExp
+  , bfLog
+  , bfSin
+  , bfCos
+  , bfTan
+  , bfAsin
+  , bfAcos
+  , bfAtan
+  , bfAtan2
 
     -- * Rounding
   , bfRoundFloat, bfRoundInt
@@ -303,6 +313,48 @@ bfRoundInt r (BigFloat x) = newBigFloat' (\bf ->
 -- | Exponentiate a word to a positive integer power.
 bfPow :: BFOpts -> BigFloat -> BigFloat -> (BigFloat, Status)
 bfPow opts (BigFloat x) (BigFloat y) = newBigFloat' (fpow opts x y)
+
+-- | Compute @pi@ using the given options.
+bfConstPi :: BFOpts -> (BigFloat,Status)
+bfConstPi opt = newBigFloat' (fconst_pi opt)
+
+-- | Compute the exponential function (@exp()@) of a number using the given
+-- options.
+bfExp :: BFOpts -> BigFloat -> (BigFloat,Status)
+bfExp opt (BigFloat x) = newBigFloat' (fexp opt x)
+
+-- | Compute the logarithm (@log()@) of a number using the given options.
+bfLog :: BFOpts -> BigFloat -> (BigFloat,Status)
+bfLog opt (BigFloat x) = newBigFloat' (flog opt x)
+
+-- | Compute the sine of a number using the given options.
+bfSin :: BFOpts -> BigFloat -> (BigFloat,Status)
+bfSin opt (BigFloat x) = newBigFloat' (fsin opt x)
+
+-- | Compute the cosine of a number using the given options.
+bfCos :: BFOpts -> BigFloat -> (BigFloat,Status)
+bfCos opt (BigFloat x) = newBigFloat' (fcos opt x)
+
+-- | Compute the tangent of a number using the given options.
+bfTan :: BFOpts -> BigFloat -> (BigFloat,Status)
+bfTan opt (BigFloat x) = newBigFloat' (ftan opt x)
+
+-- | Compute the arcsine of a number using the given options.
+bfAsin :: BFOpts -> BigFloat -> (BigFloat,Status)
+bfAsin opt (BigFloat x) = newBigFloat' (fasin opt x)
+
+-- | Compute the arccosine of a number using the given options.
+bfAcos :: BFOpts -> BigFloat -> (BigFloat,Status)
+bfAcos opt (BigFloat x) = newBigFloat' (facos opt x)
+
+-- | Compute the arctangent of a number using the given options.
+bfAtan :: BFOpts -> BigFloat -> (BigFloat,Status)
+bfAtan opt (BigFloat x) = newBigFloat' (fatan opt x)
+
+-- | Compute the two-argument arctangent function of two numbers using the given
+-- options.
+bfAtan2 :: BFOpts -> BigFloat -> BigFloat -> (BigFloat, Status)
+bfAtan2 opts (BigFloat x) (BigFloat y) = newBigFloat' (fatan2 opts x y)
 
 -- | Constant to a 'Double'
 bfToDouble :: RoundMode -> BigFloat -> (Double, Status)

--- a/src/LibBF/Mutable.hsc
+++ b/src/LibBF/Mutable.hsc
@@ -51,7 +51,16 @@ module LibBF.Mutable
   , fpow
   , fround
   , frint
-
+  , fconst_pi
+  , fexp
+  , flog
+  , fsin
+  , fcos
+  , ftan
+  , fasin
+  , facos
+  , fatan
+  , fatan2
 
   -- * Convert from a number
   , toDouble
@@ -391,7 +400,35 @@ foreign import ccall "bf_rint"
 foreign import ccall "bf_sqrt"
   bf_sqrt :: Ptr BF -> Ptr BF -> LimbT -> FlagsT -> IO Status
 
+foreign import ccall "bf_const_pi"
+  bf_const_pi :: Ptr BF -> LimbT -> FlagsT -> IO Status
 
+foreign import ccall "bf_exp"
+  bf_exp :: Ptr BF -> Ptr BF -> LimbT -> FlagsT -> IO Status
+
+foreign import ccall "bf_log"
+  bf_log :: Ptr BF -> Ptr BF -> LimbT -> FlagsT -> IO Status
+
+foreign import ccall "bf_sin"
+  bf_sin :: Ptr BF -> Ptr BF -> LimbT -> FlagsT -> IO Status
+
+foreign import ccall "bf_cos"
+  bf_cos :: Ptr BF -> Ptr BF -> LimbT -> FlagsT -> IO Status
+
+foreign import ccall "bf_tan"
+  bf_tan :: Ptr BF -> Ptr BF -> LimbT -> FlagsT -> IO Status
+
+foreign import ccall "bf_asin"
+  bf_asin :: Ptr BF -> Ptr BF -> LimbT -> FlagsT -> IO Status
+
+foreign import ccall "bf_acos"
+  bf_acos :: Ptr BF -> Ptr BF -> LimbT -> FlagsT -> IO Status
+
+foreign import ccall "bf_atan"
+  bf_atan :: Ptr BF -> Ptr BF -> LimbT -> FlagsT -> IO Status
+
+foreign import ccall "bf_atan2"
+  bf_atan2 :: Ptr BF -> Ptr BF -> Ptr BF -> LimbT -> FlagsT -> IO Status
 
 bfArith :: (Ptr BF -> Ptr BF -> Ptr BF -> LimbT -> FlagsT -> IO Status) ->
            BFOpts -> BF -> BF -> BF -> IO Status
@@ -487,8 +524,51 @@ frint (RoundMode r) = bf1 (\ptr -> bf_rint ptr (fromIntegral r :: CInt))
 fpow :: BFOpts -> BF -> BF -> BF -> IO Status
 fpow (BFOpts prec flags) = bf3 (\out in1 in2 -> bf_pow out in1 in2 prec flags)
 
+-- | Compute @pi@ to the specified precision and store the result in the
+-- argument.
+fconst_pi :: BFOpts -> BF -> IO Status
+fconst_pi (BFOpts p f) (BF fout) = withForeignPtr fout \out -> bf_const_pi out p f
 
+-- | Compute the exponential function (@exp()@) of the first number and store
+-- the result in the second.
+fexp :: BFOpts -> BF -> BF -> IO Status
+fexp (BFOpts p f) = bf2 (\res inp -> bf_exp res inp p f)
 
+-- | Compute the logarithm (@log()@) of the first number and store the result in
+-- the second.
+flog :: BFOpts -> BF -> BF -> IO Status
+flog (BFOpts p f) = bf2 (\res inp -> bf_log res inp p f)
+
+-- | Compute the sine of the first number and store the result in the second.
+fsin :: BFOpts -> BF -> BF -> IO Status
+fsin (BFOpts p f) = bf2 (\res inp -> bf_sin res inp p f)
+
+-- | Compute the cosine of the first number and store the result in the second.
+fcos :: BFOpts -> BF -> BF -> IO Status
+fcos (BFOpts p f) = bf2 (\res inp -> bf_cos res inp p f)
+
+-- | Compute the tangent of the first number and store the result in the second.
+ftan :: BFOpts -> BF -> BF -> IO Status
+ftan (BFOpts p f) = bf2 (\res inp -> bf_tan res inp p f)
+
+-- | Compute the arcsine of the first number and store the result in the second.
+fasin :: BFOpts -> BF -> BF -> IO Status
+fasin (BFOpts p f) = bf2 (\res inp -> bf_asin res inp p f)
+
+-- | Compute the arccosine of the first number and store the result in the
+-- second.
+facos :: BFOpts -> BF -> BF -> IO Status
+facos (BFOpts p f) = bf2 (\res inp -> bf_acos res inp p f)
+
+-- | Compute the arctangent of the first number and store the result in the
+-- second.
+fatan :: BFOpts -> BF -> BF -> IO Status
+fatan (BFOpts p f) = bf2 (\res inp -> bf_atan res inp p f)
+
+-- | Compute the two-argument arctangent function (@atan2()@) of the first two
+-- numbers and store the result in the second.
+fatan2 :: BFOpts -> BF -> BF -> BF -> IO Status
+fatan2 (BFOpts prec flags) = bf3 (\out in1 in2 -> bf_atan2 out in1 in2 prec flags)
 
 
 --------------------------------------------------------------------------------

--- a/tests/RunUnitTests.hs
+++ b/tests/RunUnitTests.hs
@@ -1,8 +1,9 @@
 {-# Language BlockArguments #-}
+{-# Language LambdaCase #-}
 module Main(main) where
 
 import Test.Tasty (TestTree, defaultMain, testGroup)
-import Test.Tasty.HUnit ((@=?), assertFailure, testCase)
+import Test.Tasty.HUnit ((@=?), assertBool, assertEqual, assertFailure, testCase)
 
 import LibBF
 
@@ -46,6 +47,12 @@ main =
         , testCase "0 <= NaN" $ False @=? bfPosZero <= bfNaN
         ]
       ]
+    , testGroup "Transcendental functions"
+      [ dblTestCase "atan2 1 2" atan2 (bfAtan2 (float64 NearEven)) 1 2
+      , dblTestCase "atan2 2 1" atan2 (bfAtan2 (float64 NearEven)) 2 1
+      , checkPredicateTestCase "sin" (bfSin (float256 NearEven)) (bfIsZero) (bfFromDouble 0)
+      , checkPredicateTestCase "exp" (bfExp (float256 NearEven)) (== (bfFromDouble 1)) (bfFromDouble 0)
+      ]
     ]
 
 statusUnderflow :: Status -> Bool
@@ -82,3 +89,23 @@ bfSubnormalTestCase :: BigFloat -> Bool -> TestTree
 bfSubnormalTestCase bf expected =
   testCase (show bf) $
   expected @=? bfIsSubnormal (float32 NearEven) bf
+
+checkPredicateTestCase ::
+  Show a =>
+  String ->
+  (a -> (BigFloat, Status)) ->
+  (BigFloat -> Bool) ->
+  a ->
+  TestTree
+checkPredicateTestCase opName opBF predicate input =
+  testCase opName $ do
+    assertEqual
+      ("Status '" ++ show bfStatus ++ "' not OK for " ++ describeOp)
+      bfStatus
+      Ok
+    assertBool
+      ("Test predicate failed on result " ++ show bfRes ++ " on " ++ describeOp)
+      (predicate bfRes)
+  where
+    (bfRes, bfStatus) = opBF input
+    describeOp = opName ++ "(" ++ show input ++ ")"


### PR DESCRIPTION
[I don't know whether there's interest in adding transcendental functions given that they're not perfect in libbf, but I'm using this patch locally (along with a hacked-up SBV).  The commit message follows.]

`libbf/readme.txt` calls out the following limitations of the
transcendental functions:

    > - In some operations (such as the transcendental ones), there is
    >   no rigourous proof of the rounding error. We expect to improve
    >   it by reusing ideas from the MPFR algorithms. Some unlikely
    >   overflow/underflow cases are also not handled in exp or pow.
    >
    > - The transcendental operations are not speed optimized and do not
    >   use an asymptotically optimal algorithm (the running time is in
    >   O(n^(1/2)*M(n)) where M(n) is the time to multiply two n bit
    >   numbers). A possible solution would be to implement a binary
    >   splitting algorithm for exp and sin/cos (see [1]) and to use a
    >   Newton based inversion to get log and atan.
    >
    > - Memory allocation errors are not always correctly reported for
    >   the transcendental operations.

However, they're in the library, and it would be useful to have access
to these basic functions in SBV.