### PR TITLE
32bit compile fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history for libBF-hs
 
+## 0.6.3 -- 2021-10-14
+
+* Fix an additional compile issue on 32-bit systems. Previously
+the argument to fmul2Exp was incorrectly specified as an `Int64`.
+
 ## 0.6.2 -- 2021-02-19
 
 * Fix a bug related to incorrect marshalling of String to C in
@@ -21,12 +26,12 @@ and fused-multiply-add.
 * Fix a compile issue on 32-bit systems.
 
 ## 0.5.2 -- 2021-01-12
-￼
+
 * Use `install-includes` over `c-sources` for header files to avoid linker
-￼ issues.
-￼
+issues.
+
 ## 0.5.1 -- 2020-07-13
-￼
+
 * Add header files to `c-sources` field to include them in `sdist`.
 
 ## 0.5.0 -- 2020-07-01

--- a/libBF.cabal
+++ b/libBF.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.2
 
 name:                libBF
-version:             0.6.2
+version:             0.6.3
 synopsis:            A binding to the libBF library.
 description:         LibBF is a C library for working with arbitray precision
                      IEEE 754 floating point numbers.

--- a/src/LibBF.hs
+++ b/src/LibBF.hs
@@ -252,7 +252,7 @@ bfMulInt :: BFOpts -> BigFloat -> Int64 -> (BigFloat,Status)
 bfMulInt opt (BigFloat x) y = newBigFloat' (fmulInt opt x y)
 
 -- | Multiply a number by @2^e@.
-bfMul2Exp :: BFOpts -> BigFloat -> Int64 -> (BigFloat,Status)
+bfMul2Exp :: BFOpts -> BigFloat -> Int -> (BigFloat,Status)
 bfMul2Exp opt (BigFloat x) e = newBigFloat' (\p ->
   do setBF x p
      fmul2Exp opt e p)
@@ -364,7 +364,7 @@ bfFromBits opts bits
   opts' = opts <> allowSubnormal
 
   p'         = fromIntegral p - 1                          :: Int
-  eMask      = (1 `shiftL` e) - 1                          :: Int64
+  eMask      = (1 `shiftL` e) - 1                          :: Int
   pMask      = (1 `shiftL` p') - 1                         :: Integer
 
   isNeg      = testBit bits (e + p')
@@ -373,9 +373,9 @@ bfFromBits opts bits
   mantVal    = mant `setBit` p'                            :: Integer
   -- accounts for the implicit 1 bit
 
-  expoBiased = eMask .&. fromInteger (bits `shiftR` p')    :: Int64
-  bias       = eMask `shiftR` 1                            :: Int64
-  expoVal    = expoBiased - bias - fromIntegral p'         :: Int64
+  expoBiased = eMask .&. fromInteger (bits `shiftR` p')    :: Int
+  bias       = eMask `shiftR` 1                            :: Int
+  expoVal    = expoBiased - bias - fromIntegral p'         :: Int
 
 
 -- | Turn a float into raw bits.

--- a/src/LibBF/Mutable.hsc
+++ b/src/LibBF/Mutable.hsc
@@ -449,8 +449,8 @@ fmulInt :: BFOpts -> BF -> Int64 -> BF -> IO Status
 fmulInt (BFOpts p f) x y z = bf2 (\out in1 -> bf_mul_si out in1 y p f) x z
 
 -- | Multiply the number by @2^e@.
-fmul2Exp :: BFOpts -> Int64 -> BF -> IO Status
-fmul2Exp (BFOpts p f) e = bf1 (\out -> bf_mul_2exp out e p f)
+fmul2Exp :: BFOpts -> Int -> BF -> IO Status
+fmul2Exp (BFOpts p f) e = bf1 (\out -> bf_mul_2exp out (fromIntegral e :: SLimbT) p f)
 
 -- | Divide two numbers, using the given settings, and store the
 -- result in the last.


### PR DESCRIPTION
Fix another instance where we were making incorrect assumptions about limb widths.  Hopefully, this is the last instance of this issue.