### PR TITLE
Fix the build with GHC 9.4+ on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history for libBF-hs
 
+## next -- ????.??.??
+
+* Fix the build on Windows with GHC 9.4, which bundles a Clang-based C
+  toolchain instead of a GCC-based one.
+
 ## 0.6.3 -- 2021-10-14
 
 * Fix an additional compile issue on 32-bit systems. Previously

--- a/libBF.cabal
+++ b/libBF.cabal
@@ -38,8 +38,19 @@ library
 
   hs-source-dirs:      src
 
-  if os(windows)
-    extra-libraries: gcc_s
+  -- Prior to GHC 9.4, Windows GHC bindists bundled a GCC-based C toolchain,
+  -- which requires linking against the GCC library to handle some of the
+  -- compiler intrinsics that appear in the optimized code. Moreover,
+  -- dynamically linking against the GCC library proves fragile, so we force
+  -- static linking by providing the full name of the static GCC library
+  -- archive.
+  --
+  -- On GHC 9.4+, Windows GHC bindists ship a Clang-based C toolchain. Clang
+  -- optimizations don't appear to require linking against anything in
+  -- particular, so it just works out of the box.
+  if !impl(ghc >= 9.4)
+    if os(windows)
+      extra-libraries: gcc_s
 
   if flag(system-libbf)
     extra-libraries: bf


### PR DESCRIPTION
As noted in #17, Windows GHC bindists bundle a Clang-based toolchain instead of a GCC-based one, which avoids the need to link against the `gcc_s` library (or anything similar) on GHC 9.4+.

Fixes #17.