### PR TITLE
Fix IEEE 754 comparison ((>) and (>=)) for BigFloat when NaN is involved

### DIFF
--- a/src/LibBF.hs
+++ b/src/LibBF.hs
@@ -158,6 +158,8 @@ instance Eq BigFloat where
 instance Ord BigFloat where
   BigFloat x < BigFloat y  = unsafe (cmpLT x y)
   BigFloat x <= BigFloat y = unsafe (cmpLEQ x y)
+  BigFloat x > BigFloat y  = unsafe (cmpLT y x)
+  BigFloat x >= BigFloat y  = unsafe (cmpLEQ y x)
 
 
 instance Hashable BigFloat where

--- a/tests/RunUnitTests.hs
+++ b/tests/RunUnitTests.hs
@@ -34,6 +34,18 @@ main =
     , testGroup "bfIsSubnormal (float32 NearEven)"
         (map (\bf -> bfSubnormalTestCase bf False)
              [bfPosZero, bfFromInt 1, bfFromInt 0, bfNaN, bfNegInf, bfPosInf])
+    , testGroup "IEEE 754 compare"
+      [ testGroup "Comparisons with NaN should always return False"
+        [ testCase "NaN > 0" $ False @=? bfNaN > bfPosZero
+        , testCase "0 > NaN" $ False @=? bfPosZero > bfNaN
+        , testCase "NaN >= 0" $ False @=? bfNaN >= bfPosZero
+        , testCase "0 >= NaN" $ False @=? bfPosZero >= bfNaN
+        , testCase "NaN < 0" $ False @=? bfNaN < bfPosZero
+        , testCase "0 < NaN" $ False @=? bfPosZero < bfNaN
+        , testCase "NaN <= 0" $ False @=? bfNaN <= bfPosZero
+        , testCase "0 <= NaN" $ False @=? bfPosZero <= bfNaN
+        ]
+      ]
     ]
 
 statusUnderflow :: Status -> Bool


### PR DESCRIPTION
This pull request fixes the `(>)` and `(>=)` operator of the `BigFloat`, which aren't IEEE 754 complaint when `NaN` is involved.

The original implementation relies on the default implementation of the `(>)` and `(>=)`. Unfortunately, the base library implemented them as negation of `(<)` and `(<=)`, which would make `nan > 1` or `1 > nan` evaluate to `True`.