### PR TITLE
CI: Fix i386 and macOS jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,11 +32,11 @@ jobs:
             ghc-version: 9.2.8
             cabal: 3.10.2.0
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
         with:
           submodules: true
 
-      - uses: haskell/actions/setup@v2
+      - uses: haskell-actions/setup@v2
         id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc-version }}
@@ -48,7 +48,7 @@ jobs:
         with:
           path-type: inherit
 
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v6
         name: Restore cabal store cache
         with:
           path: |
@@ -94,7 +94,7 @@ jobs:
         if: runner.os == 'Windows'
         run: ldd $(cabal list-bin test:libBF-tests)
 
-      - uses: actions/cache/save@v3
+      - uses: actions/cache/save@v6
         name: Save cabal store cache
         if: always()
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
         cabal: [ '3.10.2.0' ]
 
         include:
-          - os: macos-12
+          - os: macos-15
             ghc-version: 9.2.8
             cabal: 3.10.2.0
           - os: windows-2022

--- a/.github/workflows/i386.yaml
+++ b/.github/workflows/i386.yaml
@@ -19,12 +19,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04]
+        ghc-version: ["9.4.8"]
     steps:
     - name: Install
       run: |
         apt-get update -y
         apt-get install -y autoconf build-essential zlib1g-dev libgmp-dev curl libncurses5 libtinfo5 libncurses5-dev libtinfo-dev
-        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_INSTALL_NO_STACK=1 sh
+        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_INSTALL_NO_STACK=1 BOOTSTRAP_HASKELL_GHC_VERSION="${{ matrix.ghc-version }}" sh
     - uses: actions/checkout@v1
     - name: Test
       run: |


### PR DESCRIPTION
Fix the i386 job by pinning a specific GHC version. Fix the macOS job by upgrading from `macos-12` (which GitHub Actions no longer supports) to `macos-15`.